### PR TITLE
Fix compilation failures on macOS

### DIFF
--- a/dengr/eight_to_fourteen.cpp
+++ b/dengr/eight_to_fourteen.cpp
@@ -37,6 +37,11 @@ namespace {
      * table to be generated at compile-time).
      */
     struct PresentByte {
+        // default constructor to allow zero-initialiser usage in array
+        constexpr PresentByte()
+          : is_present(false)
+          , value(0)
+          {}
         bool is_present; // if false, consider this value to be 'null'
         Byte value; // the value stored, to be ignored if is_present is false
     };
@@ -58,7 +63,9 @@ namespace {
          */
         constexpr DecoderLookupTable(
             const ChannelByte encoding_table[256]
-        ) {
+        )
+          : lookup_table()// zero-initialise
+          {
             // construct decode table from inverse of encode table
             for (std::size_t i = 0; i < 256; i++) {
                 // all zero-initialised elements will have is_present set to false

--- a/dengr/eight_to_fourteen.cpp
+++ b/dengr/eight_to_fourteen.cpp
@@ -57,7 +57,7 @@ namespace {
          * read from to construct the decoder lookup table
          */
         constexpr DecoderLookupTable(
-            const std::array<ChannelByte, 256> encoding_table
+            const ChannelByte encoding_table[256]
         ) {
             // construct decode table from inverse of encode table
             for (std::size_t i = 0; i < 256; i++) {
@@ -77,8 +77,8 @@ namespace {
              * in this case, element #0 is our 'null' element since we know it's
              * empty, as EFM bit pattern 0 is not valid
              */
-            return i < this->lookup_table.size() ? this->lookup_table[i]
-                                                 : this->lookup_table[0];
+            return i < 16384 ? this->lookup_table[i]
+                             : this->lookup_table[0];
         }
 
     private:
@@ -87,7 +87,7 @@ namespace {
          * we need this many positions to properly map the 14-bit EFM codeword
          * values
          */
-        std::array<PresentByte, 16384> lookup_table;
+        PresentByte lookup_table[16384];
     };
 }
 
@@ -95,7 +95,7 @@ namespace com::saxbophone::dengr::eight_to_fourteen {
     /**
      * @brief Lookup table used to encode 8-bit bytes into 14-bit EFM codes
      */
-    static constexpr std::array<ChannelByte, 256> ENCODING_TABLE = {
+    static constexpr ChannelByte ENCODING_TABLE[256] = {
         0b01001000100000,
         0b10000100000000,
         0b10010000100000,

--- a/dengr/scrambling.cpp
+++ b/dengr/scrambling.cpp
@@ -47,7 +47,9 @@ namespace {
          * this is the default constructor. it computes the scrambling table
          * according to ECMA-130, Annex B.
          */
-        constexpr ScramblerLookupTable() {
+        constexpr ScramblerLookupTable()
+            : lookup_table() // zero-initialise
+            {
             /*
              * this algorithm is based on that used in joshua_saxby_scrambler()
              * within the Python script 'ecma_130_annex_b_scrambler.py'

--- a/dengr/scrambling.cpp
+++ b/dengr/scrambling.cpp
@@ -48,8 +48,8 @@ namespace {
          * according to ECMA-130, Annex B.
          */
         constexpr ScramblerLookupTable()
-            : lookup_table() // zero-initialise
-            {
+          : lookup_table() // zero-initialise
+          {
             /*
              * this algorithm is based on that used in joshua_saxby_scrambler()
              * within the Python script 'ecma_130_annex_b_scrambler.py'

--- a/dengr/scrambling.cpp
+++ b/dengr/scrambling.cpp
@@ -117,7 +117,7 @@ namespace {
          * the lookup table has 2340 bytes because first twelve sector bytes
          * are not scrambled
          */
-        std::array<Byte, 2340> lookup_table;
+        Byte lookup_table[2340];
     };
 }
 


### PR DESCRIPTION
Before merging this in, I'd like first to clarify:
- Whether it's the initialisation lists / `constexpr` constructor for `PresentByte` that have fixed it solely, in which case, whether it's possible to revert back to using `std:array` rather than plain arrays.
- Whether this discrepancy between Linux/macOS indicates an omission or error in the C++ stdlib, runtime or toolchains of either.

Also, before merging this, I will (once satisfied), remove macOS from the allowed-failures setting on the Travis-CI build matrix.