### PR TITLE
Add support for Windows Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ before_script:
   - cmake -G "$CMAKE_GENERATOR" ..
 script:
   - cmake --build . -j
-  - ./unit_tests
+  - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 before_script:
-  - cmake -G "$CMAKE_GENERATOR" .
-script:
-  - cmake --build build
   - cd build
+  - cmake -G "$CMAKE_GENERATOR" ..
+script:
+  - cmake --build . -j
   - ./unit_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
           packages:
             - g++-10
       env:
-        - MATRIX_EVAL="CXX=g++-10"
+        - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=g++-10"
     # Clang 10 on Linux
     - os: linux
       addons:
@@ -25,17 +25,21 @@ matrix:
           packages:
             - clang-10
       env:
-        - MATRIX_EVAL="CXX=clang++-10"
+        - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++-10"
     # Clang 10 on macOS
     - os: osx
       osx_image: xcode10.3 # this image has CLang 10.0.1 (same as Linux) and CMake 3.15
       env:
-        - MATRIX_EVAL="CXX=clang++"
+        - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++"
+    # MSVC 2017 on Windows
+    - os: windows
+      env:
+        - MATRIX_EVAL="CMAKE_GENERATOR='Visual Studio 15 2017'"
 before_install:
   - eval "${MATRIX_EVAL}"
 before_script:
-  - cd build
-  - cmake ..
+  - cmake -G "$CMAKE_GENERATOR" .
 script:
-  - make -j -k
+  - cmake --build build
+  - cd build
   - ./unit_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,10 @@ set_target_properties(
     dengr PROPERTIES VERSION ${DENGR_VERSION_STRING}
     SOVERSION ${PROJECT_VERSION_MAJOR}
 )
-# link DENGR with C math library
-target_link_libraries(dengr m)
+# link DENGR with C math library if we're on Linux
+if (UNIX AND NOT APPLE)
+    target_link_libraries(dengr m)
+endif()
 
 # the dengr executable --this is the command-line program
 add_executable(dengr-cli ${DENGR_CLI_SOURCE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # MSVC options appear unable to be set using this method, so they are set here instead
 if (MSVC)
-    add_compile_options(/Za) # /Za disables extensions, hence build in more standards-compliant mode
+    # add_compile_options(...)
 endif()
 
 # begin dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_cxx_compiler_flag_if_supported("-Wno-error=unused-function")
     enable_cxx_compiler_flag_if_supported("-Wno-error=unused-variable")
     enable_cxx_compiler_flag_if_supported("-Wno-error=unused-parameter")
+    # BEGIN Windows/MSVC Compiler flags
+    enable_cxx_compiler_flag_if_supported("/Za") # disable compiler extensions, run in more standard-compliant mode
+    # END Windows/MSVC Compiler flags
 endif()
 
 # begin dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # https://gist.github.com/saxbophone/b98bc600043c1ffa95dd73843e1ea6f3#file-cmakelists-txt
 
 # begin basic metadata
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 project(dengr VERSION 0.0.0 LANGUAGES CXX)
 
@@ -64,9 +64,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_cxx_compiler_flag_if_supported("-Wno-error=unused-function")
     enable_cxx_compiler_flag_if_supported("-Wno-error=unused-variable")
     enable_cxx_compiler_flag_if_supported("-Wno-error=unused-parameter")
-    # BEGIN Windows/MSVC Compiler flags
-    enable_cxx_compiler_flag_if_supported("/Za") # disable compiler extensions, run in more standard-compliant mode
-    # END Windows/MSVC Compiler flags
+endif()
+
+# MSVC options appear unable to be set using this method, so they are set here instead
+if (MSVC)
+    add_compile_options(/Za) # /Za disables extensions, hence build in more standards-compliant mode
 endif()
 
 # begin dependencies

--- a/dengr/eight_to_fourteen.cpp
+++ b/dengr/eight_to_fourteen.cpp
@@ -20,6 +20,11 @@
  */
 #include <array>
 
+// MSVC doesn't support the alternative operators out of the box
+#ifdef _MSC_VER
+#include <iso646.h>
+#endif
+
 #include "Byte.hpp"
 #include "ChannelByte.hpp"
 #include "eight_to_fourteen.hpp"


### PR DESCRIPTION
Caveat: Had to add the iso646 header to one file as MSVC is not a fully standards compliant compiler, also changed all builds to explicitly state the CMake generator they will use and build using CMake's --build mode because I don't know or want to know how to call MSVC from the command-line. That, and letting CMake handle this for me keeps the build instructions more simple that way.