### PR TITLE
Convert MSVC warnings to errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # MSVC options appear unable to be set using this method, so they are set here instead
 if (MSVC)
-    add_compile_options(/WX /W4) # treat all warnings as errors, set warning level 4
+    add_compile_options(/WX /W3) # treat all warnings as errors, set warning level 3
 endif()
 
 # begin dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # MSVC options appear unable to be set using this method, so they are set here instead
 if (MSVC)
-    # add_compile_options(...)
+    add_compile_options(/WX /W2) # treat all warnings as errors
 endif()
 
 # begin dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # MSVC options appear unable to be set using this method, so they are set here instead
 if (MSVC)
-    add_compile_options(/WX /W2) # treat all warnings as errors
+    add_compile_options(/WX /W4) # treat all warnings as errors, set warning level 4
 endif()
 
 # begin dependencies

--- a/dengr/eight_to_fourteen.cpp
+++ b/dengr/eight_to_fourteen.cpp
@@ -72,7 +72,7 @@ namespace {
             for (std::size_t i = 0; i < 256; i++) {
                 // all zero-initialised elements will have is_present set to false
                 this->lookup_table[encoding_table[i]].is_present = true;
-                this->lookup_table[encoding_table[i]].value = i;
+                this->lookup_table[encoding_table[i]].value = (std::uint8_t)i;
             }
         }
 


### PR DESCRIPTION
Add necessary MSVC build flag to convert warnings to errors, also explicitly set the warning level.

I was going to set the warning level to 4, but that gives lots of curious warnings from my unit tests, probably generated by the funky stuff the unit test framework does and I have no intention of fixing them, so setting the warning level to 3 (which appears to be the default even though I'm supposedly running MSVC from the command-line, from which the default level should be 1).

Fixed one offending line of code to get the MSVC build passing. Hurrah for the higher error detection net produced by testing on multiple compilers and platforms! :D