### PR TITLE
Use Catch2's CMake integration to enable auto-discovery of test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ before_script:
   - cmake -G "$CMAKE_GENERATOR" ..
 script:
   - cmake --build . -j
-  - ctest -V
+  - ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ if (MSVC)
     add_compile_options(/WX /W3) # treat all warnings as errors, set warning level 3
 endif()
 
+# add custom dependencies directory
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
 # begin dependencies
 
 # ...Add additional dependencies here...
@@ -109,7 +112,12 @@ set_target_properties(dengr-cli PROPERTIES OUTPUT_NAME dengr)
 add_executable(unit_tests ${TEST_SOURCES})
 target_link_libraries(unit_tests dengr)
 enable_testing()
-add_test(unit_tests unit_tests)
+
+# auto-discover and add Catch2 tests from unit tests program
+include(CTest)
+include(Catch)
+
+catch_discover_tests(unit_tests)
 
 install(
     TARGETS dengr

--- a/cmake/Modules/Catch.cmake
+++ b/cmake/Modules/Catch.cmake
@@ -1,0 +1,175 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+Catch
+-----
+
+This module defines a function to help use the Catch test framework.
+
+The :command:`catch_discover_tests` discovers tests by asking the compiled test
+executable to enumerate its tests.  This does not require CMake to be re-run
+when tests change.  However, it may not work in a cross-compiling environment,
+and setting test properties is less convenient.
+
+This command is intended to replace use of :command:`add_test` to register
+tests, and will create a separate CTest test for each Catch test case.  Note
+that this is in some cases less efficient, as common set-up and tear-down logic
+cannot be shared by multiple test cases executing in the same instance.
+However, it provides more fine-grained pass/fail information to CTest, which is
+usually considered as more beneficial.  By default, the CTest test name is the
+same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
+
+.. command:: catch_discover_tests
+
+  Automatically add tests with CTest by querying the compiled test executable
+  for available tests::
+
+    catch_discover_tests(target
+                         [TEST_SPEC arg1...]
+                         [EXTRA_ARGS arg1...]
+                         [WORKING_DIRECTORY dir]
+                         [TEST_PREFIX prefix]
+                         [TEST_SUFFIX suffix]
+                         [PROPERTIES name1 value1...]
+                         [TEST_LIST var]
+    )
+
+  ``catch_discover_tests`` sets up a post-build command on the test executable
+  that generates the list of tests by parsing the output from running the test
+  with the ``--list-test-names-only`` argument.  This ensures that the full
+  list of tests is obtained.  Since test discovery occurs at build time, it is
+  not necessary to re-run CMake when the list of tests changes.
+  However, it requires that :prop_tgt:`CROSSCOMPILING_EMULATOR` is properly set
+  in order to function in a cross-compiling environment.
+
+  Additionally, setting properties on tests is somewhat less convenient, since
+  the tests are not available at CMake time.  Additional test properties may be
+  assigned to the set of tests as a whole using the ``PROPERTIES`` option.  If
+  more fine-grained test control is needed, custom content may be provided
+  through an external CTest script using the :prop_dir:`TEST_INCLUDE_FILES`
+  directory property.  The set of discovered tests is made accessible to such a
+  script via the ``<target>_TESTS`` variable.
+
+  The options are:
+
+  ``target``
+    Specifies the Catch executable, which must be a known CMake executable
+    target.  CMake will substitute the location of the built executable when
+    running the test.
+
+  ``TEST_SPEC arg1...``
+    Specifies test cases, wildcarded test cases, tags and tag expressions to
+    pass to the Catch executable with the ``--list-test-names-only`` argument.
+
+  ``EXTRA_ARGS arg1...``
+    Any extra arguments to pass on the command line to each test case.
+
+  ``WORKING_DIRECTORY dir``
+    Specifies the directory in which to run the discovered test cases.  If this
+    option is not provided, the current binary directory is used.
+
+  ``TEST_PREFIX prefix``
+    Specifies a ``prefix`` to be prepended to the name of each discovered test
+    case.  This can be useful when the same test executable is being used in
+    multiple calls to ``catch_discover_tests()`` but with different
+    ``TEST_SPEC`` or ``EXTRA_ARGS``.
+
+  ``TEST_SUFFIX suffix``
+    Similar to ``TEST_PREFIX`` except the ``suffix`` is appended to the name of
+    every discovered test case.  Both ``TEST_PREFIX`` and ``TEST_SUFFIX`` may
+    be specified.
+
+  ``PROPERTIES name1 value1...``
+    Specifies additional properties to be set on all tests discovered by this
+    invocation of ``catch_discover_tests``.
+
+  ``TEST_LIST var``
+    Make the list of tests available in the variable ``var``, rather than the
+    default ``<target>_TESTS``.  This can be useful when the same test
+    executable is being used in multiple calls to ``catch_discover_tests()``.
+    Note that this variable is only available in CTest.
+
+#]=======================================================================]
+
+#------------------------------------------------------------------------------
+function(catch_discover_tests TARGET)
+  cmake_parse_arguments(
+    ""
+    ""
+    "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST"
+    "TEST_SPEC;EXTRA_ARGS;PROPERTIES"
+    ${ARGN}
+  )
+
+  if(NOT _WORKING_DIRECTORY)
+    set(_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+  if(NOT _TEST_LIST)
+    set(_TEST_LIST ${TARGET}_TESTS)
+  endif()
+
+  ## Generate a unique name based on the extra arguments
+  string(SHA1 args_hash "${_TEST_SPEC} ${_EXTRA_ARGS}")
+  string(SUBSTRING ${args_hash} 0 7 args_hash)
+
+  # Define rule to generate test list for aforementioned test executable
+  set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_include-${args_hash}.cmake")
+  set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_tests-${args_hash}.cmake")
+  get_property(crosscompiling_emulator
+    TARGET ${TARGET}
+    PROPERTY CROSSCOMPILING_EMULATOR
+  )
+  add_custom_command(
+    TARGET ${TARGET} POST_BUILD
+    BYPRODUCTS "${ctest_tests_file}"
+    COMMAND "${CMAKE_COMMAND}"
+            -D "TEST_TARGET=${TARGET}"
+            -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>"
+            -D "TEST_EXECUTOR=${crosscompiling_emulator}"
+            -D "TEST_WORKING_DIR=${_WORKING_DIRECTORY}"
+            -D "TEST_SPEC=${_TEST_SPEC}"
+            -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"
+            -D "TEST_PROPERTIES=${_PROPERTIES}"
+            -D "TEST_PREFIX=${_TEST_PREFIX}"
+            -D "TEST_SUFFIX=${_TEST_SUFFIX}"
+            -D "TEST_LIST=${_TEST_LIST}"
+            -D "CTEST_FILE=${ctest_tests_file}"
+            -P "${_CATCH_DISCOVER_TESTS_SCRIPT}"
+    VERBATIM
+  )
+
+  file(WRITE "${ctest_include_file}"
+    "if(EXISTS \"${ctest_tests_file}\")\n"
+    "  include(\"${ctest_tests_file}\")\n"
+    "else()\n"
+    "  add_test(${TARGET}_NOT_BUILT-${args_hash} ${TARGET}_NOT_BUILT-${args_hash})\n"
+    "endif()\n"
+  )
+
+  if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0") 
+    # Add discovered tests to directory TEST_INCLUDE_FILES
+    set_property(DIRECTORY
+      APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
+    )
+  else()
+    # Add discovered tests as directory TEST_INCLUDE_FILE if possible
+    get_property(test_include_file_set DIRECTORY PROPERTY TEST_INCLUDE_FILE SET)
+    if (NOT ${test_include_file_set})
+      set_property(DIRECTORY
+        PROPERTY TEST_INCLUDE_FILE "${ctest_include_file}"
+      )
+    else()
+      message(FATAL_ERROR
+        "Cannot set more than one TEST_INCLUDE_FILE"
+      )
+    endif()
+  endif()
+
+endfunction()
+
+###############################################################################
+
+set(_CATCH_DISCOVER_TESTS_SCRIPT
+  ${CMAKE_CURRENT_LIST_DIR}/CatchAddTests.cmake
+)

--- a/cmake/Modules/CatchAddTests.cmake
+++ b/cmake/Modules/CatchAddTests.cmake
@@ -1,0 +1,81 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+set(prefix "${TEST_PREFIX}")
+set(suffix "${TEST_SUFFIX}")
+set(spec ${TEST_SPEC})
+set(extra_args ${TEST_EXTRA_ARGS})
+set(properties ${TEST_PROPERTIES})
+set(script)
+set(suite)
+set(tests)
+
+function(add_command NAME)
+  set(_args "")
+  foreach(_arg ${ARGN})
+    if(_arg MATCHES "[^-./:a-zA-Z0-9_]")
+      set(_args "${_args} [==[${_arg}]==]") # form a bracket_argument
+    else()
+      set(_args "${_args} ${_arg}")
+    endif()
+  endforeach()
+  set(script "${script}${NAME}(${_args})\n" PARENT_SCOPE)
+endfunction()
+
+# Run test executable to get list of available tests
+if(NOT EXISTS "${TEST_EXECUTABLE}")
+  message(FATAL_ERROR
+    "Specified test executable '${TEST_EXECUTABLE}' does not exist"
+  )
+endif()
+execute_process(
+  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-names-only
+  OUTPUT_VARIABLE output
+  RESULT_VARIABLE result
+)
+# Catch --list-test-names-only reports the number of tests, so 0 is... surprising
+if(${result} EQUAL 0)
+  message(WARNING
+    "Test executable '${TEST_EXECUTABLE}' contains no tests!\n"
+  )
+elseif(${result} LESS 0)
+  message(FATAL_ERROR
+    "Error running test executable '${TEST_EXECUTABLE}':\n"
+    "  Result: ${result}\n"
+    "  Output: ${output}\n"
+  )
+endif()
+
+string(REPLACE "\n" ";" output "${output}")
+
+# Parse output
+foreach(line ${output})
+  set(test ${line})
+  # Escape characters in test case names that would be parsed by Catch2
+  set(test_name ${test})
+  foreach(char , [ ])
+    string(REPLACE ${char} "\\${char}" test_name ${test_name})
+  endforeach(char)
+  # ...and add to script
+  add_command(add_test
+    "${prefix}${test}${suffix}"
+    ${TEST_EXECUTOR}
+    "${TEST_EXECUTABLE}"
+    "${test_name}"
+    ${extra_args}
+  )
+  add_command(set_tests_properties
+    "${prefix}${test}${suffix}"
+    PROPERTIES
+    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+    ${properties}
+  )
+  list(APPEND tests "${prefix}${test}${suffix}")
+endforeach()
+
+# Create a list of all discovered tests, which users may use to e.g. set
+# properties on the tests
+add_command(set ${TEST_LIST} ${tests})
+
+# Write CTest script
+file(WRITE "${CTEST_FILE}" "${script}")

--- a/cmake/Modules/ParseAndAddCatchTests.cmake
+++ b/cmake/Modules/ParseAndAddCatchTests.cmake
@@ -1,0 +1,225 @@
+#==================================================================================================#
+#  supported macros                                                                                #
+#    - TEST_CASE,                                                                                  #
+#    - SCENARIO,                                                                                   #
+#    - TEST_CASE_METHOD,                                                                           #
+#    - CATCH_TEST_CASE,                                                                            #
+#    - CATCH_SCENARIO,                                                                             #
+#    - CATCH_TEST_CASE_METHOD.                                                                     #
+#                                                                                                  #
+#  Usage                                                                                           #
+# 1. make sure this module is in the path or add this otherwise:                                   #
+#    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake.modules/")              #
+# 2. make sure that you've enabled testing option for the project by the call:                     #
+#    enable_testing()                                                                              #
+# 3. add the lines to the script for testing target (sample CMakeLists.txt):                       #
+#        project(testing_target)                                                                   #
+#        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake.modules/")          #
+#        enable_testing()                                                                          #
+#                                                                                                  #
+#        find_path(CATCH_INCLUDE_DIR "catch.hpp")                                                  #
+#        include_directories(${INCLUDE_DIRECTORIES} ${CATCH_INCLUDE_DIR})                          #
+#                                                                                                  #
+#        file(GLOB SOURCE_FILES "*.cpp")                                                           #
+#        add_executable(${PROJECT_NAME} ${SOURCE_FILES})                                           #
+#                                                                                                  #
+#        include(ParseAndAddCatchTests)                                                            #
+#        ParseAndAddCatchTests(${PROJECT_NAME})                                                    #
+#                                                                                                  #
+# The following variables affect the behavior of the script:                                       #
+#                                                                                                  #
+#    PARSE_CATCH_TESTS_VERBOSE (Default OFF)                                                       #
+#    -- enables debug messages                                                                     #
+#    PARSE_CATCH_TESTS_NO_HIDDEN_TESTS (Default OFF)                                               #
+#    -- excludes tests marked with [!hide], [.] or [.foo] tags                                     #
+#    PARSE_CATCH_TESTS_ADD_FIXTURE_IN_TEST_NAME (Default ON)                                       #
+#    -- adds fixture class name to the test name                                                   #
+#    PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME (Default ON)                                        #
+#    -- adds cmake target name to the test name                                                    #
+#    PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS (Default OFF)                                      #
+#    -- causes CMake to rerun when file with tests changes so that new tests will be discovered    #
+#                                                                                                  #
+# One can also set (locally) the optional variable OptionalCatchTestLauncher to precise the way    #
+# a test should be run. For instance to use test MPI, one can write                                #
+#     set(OptionalCatchTestLauncher ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUMPROC})                 #
+# just before calling this ParseAndAddCatchTests function                                          #
+#                                                                                                  #
+# The AdditionalCatchParameters optional variable can be used to pass extra argument to the test   #
+# command. For example, to include successful tests in the output, one can write                   #
+#     set(AdditionalCatchParameters --success)                                                     #
+#                                                                                                  #
+# After the script, the ParseAndAddCatchTests_TESTS property for the target, and for each source   #
+# file in the target is set, and contains the list of the tests extracted from that target, or     #
+# from that file. This is useful, for example to add further labels or properties to the tests.    #
+#                                                                                                  #
+#==================================================================================================#
+
+if (CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 2.8.8)
+  message(FATAL_ERROR "ParseAndAddCatchTests requires CMake 2.8.8 or newer")
+endif()
+
+option(PARSE_CATCH_TESTS_VERBOSE "Print Catch to CTest parser debug messages" OFF)
+option(PARSE_CATCH_TESTS_NO_HIDDEN_TESTS "Exclude tests with [!hide], [.] or [.foo] tags" OFF)
+option(PARSE_CATCH_TESTS_ADD_FIXTURE_IN_TEST_NAME "Add fixture class name to the test name" ON)
+option(PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME "Add target name to the test name" ON)
+option(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS "Add test file to CMAKE_CONFIGURE_DEPENDS property" OFF)
+
+function(ParseAndAddCatchTests_PrintDebugMessage)
+    if(PARSE_CATCH_TESTS_VERBOSE)
+            message(STATUS "ParseAndAddCatchTests: ${ARGV}")
+    endif()
+endfunction()
+
+# This removes the contents between
+#  - block comments (i.e. /* ... */)
+#  - full line comments (i.e. // ... )
+# contents have been read into '${CppCode}'.
+# !keep partial line comments
+function(ParseAndAddCatchTests_RemoveComments CppCode)
+  string(ASCII 2 CMakeBeginBlockComment)
+  string(ASCII 3 CMakeEndBlockComment)
+  string(REGEX REPLACE "/\\*" "${CMakeBeginBlockComment}" ${CppCode} "${${CppCode}}")
+  string(REGEX REPLACE "\\*/" "${CMakeEndBlockComment}" ${CppCode} "${${CppCode}}")
+  string(REGEX REPLACE "${CMakeBeginBlockComment}[^${CMakeEndBlockComment}]*${CMakeEndBlockComment}" "" ${CppCode} "${${CppCode}}")
+  string(REGEX REPLACE "\n[ \t]*//+[^\n]+" "\n" ${CppCode} "${${CppCode}}")
+
+  set(${CppCode} "${${CppCode}}" PARENT_SCOPE)
+endfunction()
+
+# Worker function
+function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
+    # If SourceFile is an object library, do not scan it (as it is not a file). Exit without giving a warning about a missing file.
+    if(SourceFile MATCHES "\\\$<TARGET_OBJECTS:.+>")
+        ParseAndAddCatchTests_PrintDebugMessage("Detected OBJECT library: ${SourceFile} this will not be scanned for tests.")
+        return()
+    endif()
+    # According to CMake docs EXISTS behavior is well-defined only for full paths.
+    get_filename_component(SourceFile ${SourceFile} ABSOLUTE)
+    if(NOT EXISTS ${SourceFile})
+        message(WARNING "Cannot find source file: ${SourceFile}")
+        return()
+    endif()
+    ParseAndAddCatchTests_PrintDebugMessage("parsing ${SourceFile}")
+    file(STRINGS ${SourceFile} Contents NEWLINE_CONSUME)
+
+    # Remove block and fullline comments
+    ParseAndAddCatchTests_RemoveComments(Contents)
+
+    # Find definition of test names
+    string(REGEX MATCHALL "[ \t]*(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)[ \t]*\\([^\)]+\\)+[ \t\n]*{+[ \t]*(//[^\n]*[Tt][Ii][Mm][Ee][Oo][Uu][Tt][ \t]*[0-9]+)*" Tests "${Contents}")
+
+    if(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS AND Tests)
+      ParseAndAddCatchTests_PrintDebugMessage("Adding ${SourceFile} to CMAKE_CONFIGURE_DEPENDS property")
+      set_property(
+        DIRECTORY
+        APPEND
+        PROPERTY CMAKE_CONFIGURE_DEPENDS ${SourceFile}
+      )
+    endif()
+
+    foreach(TestName ${Tests})
+        # Strip newlines
+        string(REGEX REPLACE "\\\\\n|\n" "" TestName "${TestName}")
+
+        # Get test type and fixture if applicable
+        string(REGEX MATCH "(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)[ \t]*\\([^,^\"]*" TestTypeAndFixture "${TestName}")
+        string(REGEX MATCH "(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)" TestType "${TestTypeAndFixture}")
+        string(REGEX REPLACE "${TestType}\\([ \t]*" "" TestFixture "${TestTypeAndFixture}")
+
+        # Get string parts of test definition
+        string(REGEX MATCHALL "\"+([^\\^\"]|\\\\\")+\"+" TestStrings "${TestName}")
+
+        # Strip wrapping quotation marks
+        string(REGEX REPLACE "^\"(.*)\"$" "\\1" TestStrings "${TestStrings}")
+        string(REPLACE "\";\"" ";" TestStrings "${TestStrings}")
+
+        # Validate that a test name and tags have been provided
+        list(LENGTH TestStrings TestStringsLength)
+        if(TestStringsLength GREATER 2 OR TestStringsLength LESS 1)
+            message(FATAL_ERROR "You must provide a valid test name and tags for all tests in ${SourceFile}")
+        endif()
+
+        # Assign name and tags
+        list(GET TestStrings 0 Name)
+        if("${TestType}" STREQUAL "SCENARIO")
+            set(Name "Scenario: ${Name}")
+        endif()
+        if(PARSE_CATCH_TESTS_ADD_FIXTURE_IN_TEST_NAME AND "${TestType}" MATCHES "(CATCH_)?TEST_CASE_METHOD" AND TestFixture )
+            set(CTestName "${TestFixture}:${Name}")
+        else()
+            set(CTestName "${Name}")
+        endif()
+        if(PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME)
+            set(CTestName "${TestTarget}:${CTestName}")
+        endif()
+        # add target to labels to enable running all tests added from this target
+        set(Labels ${TestTarget})
+        if(TestStringsLength EQUAL 2)
+            list(GET TestStrings 1 Tags)
+            string(TOLOWER "${Tags}" Tags)
+            # remove target from labels if the test is hidden
+            if("${Tags}" MATCHES ".*\\[!?(hide|\\.)\\].*")
+                list(REMOVE_ITEM Labels ${TestTarget})
+            endif()
+            string(REPLACE "]" ";" Tags "${Tags}")
+            string(REPLACE "[" "" Tags "${Tags}")
+        else()
+          # unset tags variable from previous loop
+          unset(Tags)
+        endif()
+
+        list(APPEND Labels ${Tags})
+
+        set(HiddenTagFound OFF)
+        foreach(label ${Labels})
+            string(REGEX MATCH "^!hide|^\\." result ${label})
+            if(result)
+                set(HiddenTagFound ON)
+                break()
+            endif(result)
+        endforeach(label)
+        if(PARSE_CATCH_TESTS_NO_HIDDEN_TESTS AND ${HiddenTagFound} AND ${CMAKE_VERSION} VERSION_LESS "3.9")
+            ParseAndAddCatchTests_PrintDebugMessage("Skipping test \"${CTestName}\" as it has [!hide], [.] or [.foo] label")
+        else()
+            ParseAndAddCatchTests_PrintDebugMessage("Adding test \"${CTestName}\"")
+            if(Labels)
+                ParseAndAddCatchTests_PrintDebugMessage("Setting labels to ${Labels}")
+            endif()
+
+            # Escape commas in the test spec
+            string(REPLACE "," "\\," Name ${Name})
+
+            # Add the test and set its properties
+            add_test(NAME "\"${CTestName}\"" COMMAND ${OptionalCatchTestLauncher} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})
+            # Old CMake versions do not document VERSION_GREATER_EQUAL, so we use VERSION_GREATER with 3.8 instead
+            if(PARSE_CATCH_TESTS_NO_HIDDEN_TESTS AND ${HiddenTagFound} AND ${CMAKE_VERSION} VERSION_GREATER "3.8")
+                ParseAndAddCatchTests_PrintDebugMessage("Setting DISABLED test property")
+                set_tests_properties("\"${CTestName}\"" PROPERTIES DISABLED ON)
+            else()
+                set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
+                                                        LABELS "${Labels}")
+            endif()
+            set_property(
+              TARGET ${TestTarget}
+              APPEND
+              PROPERTY ParseAndAddCatchTests_TESTS "\"${CTestName}\"")
+            set_property(
+              SOURCE ${SourceFile}
+              APPEND
+              PROPERTY ParseAndAddCatchTests_TESTS "\"${CTestName}\"")
+        endif()
+
+
+    endforeach()
+endfunction()
+
+# entry point
+function(ParseAndAddCatchTests TestTarget)
+    ParseAndAddCatchTests_PrintDebugMessage("Started parsing ${TestTarget}")
+    get_target_property(SourceFiles ${TestTarget} SOURCES)
+    ParseAndAddCatchTests_PrintDebugMessage("Found the following sources: ${SourceFiles}")
+    foreach(SourceFile ${SourceFiles})
+        ParseAndAddCatchTests_ParseFile(${SourceFile} ${TestTarget})
+    endforeach()
+    ParseAndAddCatchTests_PrintDebugMessage("Finished parsing ${TestTarget}")
+endfunction()


### PR DESCRIPTION
This causes the unit testing output to be more detailed, CTest now shows each (high-level) test case being run