### PR TITLE
Convert bits to pits

### DIFF
--- a/dengr/ChannelBit.hpp
+++ b/dengr/ChannelBit.hpp
@@ -1,0 +1,39 @@
+/**
+ * @file
+ *
+ * @remarks This source file forms part of DENGR, a piece of software which
+ * produces disc images which produce visible images on the recording side when
+ * burned to Compact Disc.
+ *
+ * @author Joshua Saxby <joshua.a.saxby@gmail.com>
+ * @date 2020
+ *
+ * @copyright Copyright (C) 2020 Joshua Saxby
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * @copyright
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef COM_SAXBOPHONE_DENGR_CHANNEL_BIT
+#define COM_SAXBOPHONE_DENGR_CHANNEL_BIT
+
+namespace com::saxbophone::dengr {
+    /**
+     * @brief Each Channel Frame comprises 588 Channel bits, these are those bits
+     */
+    typedef bool ChannelBit;
+}
+
+#endif // include guard

--- a/dengr/ChannelBit.hpp
+++ b/dengr/ChannelBit.hpp
@@ -29,11 +29,21 @@
 #ifndef COM_SAXBOPHONE_DENGR_CHANNEL_BIT
 #define COM_SAXBOPHONE_DENGR_CHANNEL_BIT
 
+#include <array>
+
+
 namespace com::saxbophone::dengr {
     /**
      * @brief Each Channel Frame comprises 588 Channel bits, these are those bits
      */
     typedef bool ChannelBit;
+
+    /**
+     * @brief Convenience typedef to allow making arrays of channel bits easier
+     * @tparam LENGTH the length of the ChannelBitArray
+     */
+    template<std::size_t LENGTH>
+    using ChannelBitArray = std::array<ChannelBit, LENGTH>;
 }
 
 #endif // include guard

--- a/dengr/Pit.hpp
+++ b/dengr/Pit.hpp
@@ -29,6 +29,9 @@
 #ifndef COM_SAXBOPHONE_DENGR_PIT
 #define COM_SAXBOPHONE_DENGR_PIT
 
+#include <array>
+
+
 // TODO: Change to namespace com::saxbophone::dengr when move to C++20 complete
 namespace com::saxbophone::dengr {
     /**
@@ -43,6 +46,13 @@ namespace com::saxbophone::dengr {
         PIT = true,   /**< A depression on the track's surface */
         LAND = false, /**< A flat area on the track's surface */
     };
+
+    /**
+     * @brief Convenience typedef to allow making arrays of pits easier
+     * @tparam LENGTH the length of the PitArray
+     */
+    template<std::size_t LENGTH>
+    using PitArray = std::array<Pit, LENGTH>;
 }
 
 #endif // include guard

--- a/dengr/eight_to_fourteen.cpp
+++ b/dengr/eight_to_fourteen.cpp
@@ -20,6 +20,8 @@
  */
 #include <array>
 
+#include <cstddef>
+
 // MSVC doesn't support the alternative operators out of the box
 #ifdef _MSC_VER
 #include <iso646.h>

--- a/dengr/physical_layer.cpp
+++ b/dengr/physical_layer.cpp
@@ -1,0 +1,49 @@
+/*
+ * This source file forms part of DENGR, a piece of software which
+ * produces disc images which produce visible images on the recording side when
+ * burned to Compact Disc.
+ *
+ * Copyright (C) 2020 Joshua Saxby <joshua.a.saxby@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <array>
+
+#include <cstddef>
+
+#include "ChannelBit.hpp"
+#include "Pit.hpp"
+
+
+namespace com::saxbophone::dengr::physical_layer {
+    template<std::size_t LENGTH>
+    std::array<Pit, LENGTH> bits_to_pits(
+        Pit previous_pit,
+        std::array<ChannelBit, LENGTH> bits
+    ) {
+        // XXX: stub implementation returning all zeroes
+        std::array<Pit, LENGTH> pits;
+        return pits;
+    }
+
+    template<std::size_t LENGTH>
+    std::array<ChannelBit, LENGTH> pits_to_bits(
+        Pit previous_pit,
+        std::array<Pit, LENGTH> pits
+    ) {
+        // XXX: stub implementation returning all zeroes
+        std::array<ChannelBit, LENGTH> bits;
+        return bits;
+    }
+}

--- a/dengr/physical_layer.cpp
+++ b/dengr/physical_layer.cpp
@@ -33,6 +33,7 @@ namespace com::saxbophone::dengr::physical_layer {
         std::array<ChannelBit, LENGTH> bits
     ) {
         // XXX: stub implementation returning all zeroes
+        // XXX: WRITE UNIT TESTS BEFORE IMPLEMENTATION, JOSH!
         std::array<Pit, LENGTH> pits;
         return pits;
     }
@@ -43,6 +44,7 @@ namespace com::saxbophone::dengr::physical_layer {
         std::array<Pit, LENGTH> pits
     ) {
         // XXX: stub implementation returning all zeroes
+        // XXX: WRITE UNIT TESTS BEFORE IMPLEMENTATION, JOSH!
         std::array<ChannelBit, LENGTH> bits;
         return bits;
     }

--- a/dengr/physical_layer.hpp
+++ b/dengr/physical_layer.hpp
@@ -1,0 +1,79 @@
+/**
+ * @file
+ *
+ * @remarks This source file forms part of DENGR, a piece of software which
+ * produces disc images which produce visible images on the recording side when
+ * burned to Compact Disc.
+ *
+ * @author Joshua Saxby <joshua.a.saxby@gmail.com>
+ * @date 2020
+ *
+ * @copyright Copyright (C) 2020 Joshua Saxby
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * @copyright
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef COM_SAXBOPHONE_DENGR_PHYSICAL_LAYER
+#define COM_SAXBOPHONE_DENGR_PHYSICAL_LAYER
+
+#include <array>
+
+#include <cstddef>
+
+#include "ChannelBit.hpp"
+#include "Pit.hpp"
+
+
+/**
+ * @brief Functions for encoding sequences of bits to sequences of Pits/Lands
+ * @details This implements the process described towards the end of ECMA-130,
+ * sec 19.4
+ */
+namespace com::saxbophone::dengr::physical_layer {
+    /**
+     * @brief Encodes an array of Channel Bits into an equal-sized array of Pits
+     * @details This uses Non-Return-to-Zero-Inverted (NRZI) encoding to encode
+     * bits into pits.
+     * @tparam LENGTH the length of the input and output arrays
+     * @param previous_pit the value of the previous Pit seen immediately before
+     * this upcoming array of Pits to be encoded
+     * @param bits the array of Channel Bits to encode
+     * @returns array of Pits representing the given input bits
+     */
+    template<std::size_t LENGTH>
+    std::array<Pit, LENGTH> bits_to_pits(
+        Pit previous_pit,
+        std::array<ChannelBit, LENGTH> bits
+    );
+
+    /**
+     * @brief Decodes an array of Pits into an equal-sized array of Channel Bits
+     * @details This uses Non-Return-to-Zero-Inverted (NRZI) encoding to decode
+     * pits into bits
+     * @tparam LENGTH the length of the input and output arrays
+     * @param previous_pit the value of the previous Pit seen immediately before
+     * this upcoming array of Pits to be decoded
+     * @param pits the array of Pits to decode
+     * @returns array of Channel Bits represented by the given input Pits
+     */
+    template<std::size_t LENGTH>
+    std::array<ChannelBit, LENGTH> pits_to_bits(
+        Pit previous_pit,
+        std::array<Pit, LENGTH> pits
+    );
+}
+
+#endif // include guard

--- a/dengr/physical_layer.hpp
+++ b/dengr/physical_layer.hpp
@@ -54,9 +54,9 @@ namespace com::saxbophone::dengr::physical_layer {
      * @returns array of Pits representing the given input bits
      */
     template<std::size_t LENGTH>
-    std::array<Pit, LENGTH> bits_to_pits(
+    PitArray<LENGTH> bits_to_pits(
         Pit previous_pit,
-        std::array<ChannelBit, LENGTH> bits
+        ChannelBitArray<LENGTH> bits
     );
 
     /**
@@ -70,10 +70,13 @@ namespace com::saxbophone::dengr::physical_layer {
      * @returns array of Channel Bits represented by the given input Pits
      */
     template<std::size_t LENGTH>
-    std::array<ChannelBit, LENGTH> pits_to_bits(
+    ChannelBitArray<LENGTH> pits_to_bits(
         Pit previous_pit,
-        std::array<Pit, LENGTH> pits
+        PitArray<LENGTH> pits
     );
 }
+
+// because these functions are templated, their implementation follows immediately
+#include "physical_layer.inl"
 
 #endif // include guard

--- a/dengr/physical_layer.inl
+++ b/dengr/physical_layer.inl
@@ -18,8 +18,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <array>
-
 #include <cstddef>
 
 #include "ChannelBit.hpp"
@@ -28,24 +26,24 @@
 
 namespace com::saxbophone::dengr::physical_layer {
     template<std::size_t LENGTH>
-    std::array<Pit, LENGTH> bits_to_pits(
+    PitArray<LENGTH> bits_to_pits(
         Pit previous_pit,
-        std::array<ChannelBit, LENGTH> bits
+        ChannelBitArray<LENGTH> bits
     ) {
         // XXX: stub implementation returning all zeroes
         // XXX: WRITE UNIT TESTS BEFORE IMPLEMENTATION, JOSH!
-        std::array<Pit, LENGTH> pits;
+        PitArray<LENGTH> pits = {};
         return pits;
     }
 
     template<std::size_t LENGTH>
-    std::array<ChannelBit, LENGTH> pits_to_bits(
+    ChannelBitArray<LENGTH> pits_to_bits(
         Pit previous_pit,
-        std::array<Pit, LENGTH> pits
+        PitArray<LENGTH> pits
     ) {
         // XXX: stub implementation returning all zeroes
         // XXX: WRITE UNIT TESTS BEFORE IMPLEMENTATION, JOSH!
-        std::array<ChannelBit, LENGTH> bits;
+        ChannelBitArray<LENGTH> bits = {};
         return bits;
     }
 }

--- a/dengr/physical_layer.inl
+++ b/dengr/physical_layer.inl
@@ -55,9 +55,17 @@ namespace com::saxbophone::dengr::physical_layer {
         Pit previous_pit,
         PitArray<LENGTH> pits
     ) {
-        // XXX: stub implementation returning all zeroes
-        // XXX: WRITE UNIT TESTS BEFORE IMPLEMENTATION, JOSH!
         ChannelBitArray<LENGTH> bits = {};
+        for (std::size_t i = 0; i < LENGTH; i++) {
+            // as long as the pit is the same as previous, send 0
+            if (pits[i] == previous_pit) {
+                bits[i] = 0b0;
+            } else {
+                // otherwise, send 1 and update the "previous pit" to last-seen
+                bits[i] = 0b1;
+                previous_pit = pits[i];
+            }
+        }
         return bits;
     }
 }

--- a/dengr/physical_layer.inl
+++ b/dengr/physical_layer.inl
@@ -18,6 +18,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <utility>
+
 #include <cstddef>
 
 #include "ChannelBit.hpp"
@@ -30,8 +32,21 @@ namespace com::saxbophone::dengr::physical_layer {
         Pit previous_pit,
         ChannelBitArray<LENGTH> bits
     ) {
-        using com::saxbophone::dengr::Pit;
-        PitArray<LENGTH> pits = {LAND, PIT, LAND, LAND, PIT, PIT, PIT, LAND,};
+        // used to keep track of what the current Pit/Land status is
+        std::pair<Pit, Pit> state = { Pit::LAND, Pit::PIT, };
+        // the first item is used as "current state", so swap if previous is PIT
+        if (previous_pit == Pit::PIT) {
+            std::swap(state.first, state.second);
+        }
+        PitArray<LENGTH> pits;
+        for (std::size_t i = 0; i < LENGTH; i++) {
+            // for each bit seen, if it's 1, swap states, otherwise, leave as-is
+            if (bits[i] == 0b1) {
+                std::swap(state.first, state.second);
+            }
+            // output the state in the first position of the pair
+            pits[i] = state.first;
+        }
         return pits;
     }
 

--- a/dengr/physical_layer.inl
+++ b/dengr/physical_layer.inl
@@ -30,9 +30,8 @@ namespace com::saxbophone::dengr::physical_layer {
         Pit previous_pit,
         ChannelBitArray<LENGTH> bits
     ) {
-        // XXX: stub implementation returning all zeroes
-        // XXX: WRITE UNIT TESTS BEFORE IMPLEMENTATION, JOSH!
-        PitArray<LENGTH> pits = {};
+        using com::saxbophone::dengr::Pit;
+        PitArray<LENGTH> pits = {LAND, PIT, LAND, LAND, PIT, PIT, PIT, LAND,};
         return pits;
     }
 

--- a/dengr/scrambling.cpp
+++ b/dengr/scrambling.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <array>
+
 #include <cstdint>
+#include <cstddef>
 
 #include "Byte.hpp"
 #include "Mode2Sector.hpp"

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -38,7 +38,10 @@ SCENARIO("Sequences of bits can be converted to sequences of pits/lands") {
         // bits are stuffed into uints here for compactness
         auto bits_pits_combination = GENERATE(
             // previous-pit pits          expected-bits
-            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b01101001, 0b01001110)
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b01101001, 0b01001110),
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b01101001, 0b10110001),
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11101010, 0b10110011),
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00110011, 0b11011101)
         );
         // extract the bit patterns for use in the test case
         ChannelBitArray<LENGTH> bits;

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -42,7 +42,13 @@ SCENARIO("Sequences of bits can be converted to/from sequences of pits/lands") {
         std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11101010, 0b10110011),
         std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00110011, 0b11011101),
         std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00100100, 0b11000111),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b00010000, 0b00011111)
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b00010000, 0b00011111),
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11001101, 0b10001001),
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b11110111, 0b01011010),
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b10010010, 0b11100011),
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00010010, 0b11100011),
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b10000000, 0b00000000),
+        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b00000000, 0b00000000)
     );
     // extract the bit patterns for use in the test case
     ChannelBitArray<LENGTH> bits;

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -36,7 +36,7 @@ SCENARIO("Sequences of bits can be converted to/from sequences of pits/lands") {
     const std::size_t LENGTH = 8;
     // bits are stuffed into uints here for compactness
     auto bits_pits_combination = GENERATE(
-        // previous-pit pits          bits
+        //                                        previous-pit bits        pits
         std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b01101001, 0b01001110),
         std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b01101001, 0b10110001),
         std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11101010, 0b10110011),

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <utility>
+#include <tuple>
 
 #include <cstddef>
 
@@ -37,17 +37,19 @@ SCENARIO("Sequences of bits can be converted to sequences of pits/lands") {
         const std::size_t LENGTH = 8;
         // bits are stuffed into uints here for compactness
         auto bits_pits_combination = GENERATE(
-            std::pair<std::uint8_t, std::uint8_t>{0b01101001, 0b01001110}
+            // previous-pit pits          expected-bits
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b01101001, 0b01001110)
         );
         // extract the bit patterns for use in the test case
         ChannelBitArray<LENGTH> bits;
         PitArray<LENGTH> pits;
         for (std::uint8_t i = 0; i < 8; i++) {
-            bits[i] = (bits_pits_combination.first & (1 << (7 - i))) != 0;
-            pits[i] = (Pit)((bits_pits_combination.second & (1 << (7 - i))) != 0);
+            bits[i] = (std::get<1>(bits_pits_combination) & (1 << (7 - i))) != 0;
+            pits[i] = (Pit)((std::get<2>(bits_pits_combination) & (1 << (7 - i))) != 0);
         }
         WHEN("The bits are passed into the pit/land encoder") {
-            PitArray<LENGTH> output = bits_to_pits(Pit::LAND, bits);
+            // also extract the previous pit value
+            PitArray<LENGTH> output = bits_to_pits(std::get<0>(bits_pits_combination), bits);
             THEN("The encoder should return a corresponding sequence of pits/lands") {
                 // output should be equal to pits, which is what's expected
                 REQUIRE(output == pits);

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -34,21 +34,23 @@ using namespace com::saxbophone::dengr::physical_layer;
 
 SCENARIO("Sequences of bits can be converted to/from sequences of pits/lands") {
     const std::size_t LENGTH = 8;
+    // convenience typedef to keep the test case data lines within limits
+    typedef std::tuple<Pit, std::uint8_t, std::uint8_t> TestData;
     // bits are stuffed into uints here for compactness
     auto bits_pits_combination = GENERATE(
-        //                                        previous-pit bits        pits
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b01101001, 0b01001110),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b01101001, 0b10110001),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11101010, 0b10110011),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00110011, 0b11011101),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00100100, 0b11000111),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b00010000, 0b00011111),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11001101, 0b10001001),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b11110111, 0b01011010),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b10010010, 0b11100011),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00010010, 0b11100011),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b10000000, 0b00000000),
-        std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b00000000, 0b00000000)
+        //    previous-pit  bits        pits
+        TestData(Pit::LAND, 0b01101001, 0b01001110),
+        TestData(Pit::PIT , 0b01101001, 0b10110001),
+        TestData(Pit::LAND, 0b11101010, 0b10110011),
+        TestData(Pit::PIT , 0b00110011, 0b11011101),
+        TestData(Pit::PIT , 0b00100100, 0b11000111),
+        TestData(Pit::LAND, 0b00010000, 0b00011111),
+        TestData(Pit::LAND, 0b11001101, 0b10001001),
+        TestData(Pit::PIT , 0b11110111, 0b01011010),
+        TestData(Pit::LAND, 0b10010010, 0b11100011),
+        TestData(Pit::PIT , 0b00010010, 0b11100011),
+        TestData(Pit::PIT , 0b10000000, 0b00000000),
+        TestData(Pit::LAND, 0b00000000, 0b00000000)
     );
     // extract the bit patterns for use in the test case
     ChannelBitArray<LENGTH> bits;

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -1,0 +1,57 @@
+/*
+ * This source file forms part of DENGR, a piece of software which
+ * produces disc images which produce visible images on the recording side when
+ * burned to Compact Disc.
+ *
+ * Copyright (C) 2020 Joshua Saxby <joshua.a.saxby@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <utility>
+
+#include <cstddef>
+
+#include "../vendor/catch.hpp"
+
+#include "../dengr/ChannelBit.hpp"
+#include "../dengr/Pit.hpp"
+#include "../dengr/physical_layer.hpp"
+
+
+using namespace com::saxbophone::dengr;
+using namespace com::saxbophone::dengr::physical_layer;
+
+SCENARIO("Sequences of bits can be converted to sequences of pits/lands") {
+    GIVEN("A sequence of Channel Bits and its corresponding sequence of pits/lands") {
+        const std::size_t LENGTH = 8;
+        // bits are stuffed into uints here for compactness
+        auto bits_pits_combination = GENERATE(
+            std::pair<std::uint8_t, std::uint8_t>{0b01101001, 0b01001110}
+        );
+        // extract the bit patterns for use in the test case
+        ChannelBitArray<LENGTH> bits;
+        PitArray<LENGTH> pits;
+        for (std::uint8_t i = 0; i < 8; i++) {
+            bits[i] = (bits_pits_combination.first & (1 << (7 - i))) != 0;
+            pits[i] = (Pit)((bits_pits_combination.second & (1 << (7 - i))) != 0);
+        }
+        WHEN("The bits are passed into the pit/land encoder") {
+            PitArray<LENGTH> output = bits_to_pits(Pit::LAND, bits);
+            THEN("The encoder should return a corresponding sequence of pits/lands") {
+                // output should be equal to pits, which is what's expected
+                REQUIRE(output == pits);
+            }
+        }
+    }
+}

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -41,7 +41,9 @@ SCENARIO("Sequences of bits can be converted to sequences of pits/lands") {
             std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b01101001, 0b01001110),
             std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b01101001, 0b10110001),
             std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b11101010, 0b10110011),
-            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00110011, 0b11011101)
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00110011, 0b11011101),
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::PIT , 0b00100100, 0b11000111),
+            std::tuple<Pit, std::uint8_t, std::uint8_t>(Pit::LAND, 0b00010000, 0b00011111)
         );
         // extract the bit patterns for use in the test case
         ChannelBitArray<LENGTH> bits;

--- a/tests/physical_layer.cpp
+++ b/tests/physical_layer.cpp
@@ -32,7 +32,7 @@
 using namespace com::saxbophone::dengr;
 using namespace com::saxbophone::dengr::physical_layer;
 
-SCENARIO("Sequences of bits can be converted to sequences of pits/lands") {
+SCENARIO("Sequences of bits can be converted to/from sequences of pits/lands") {
     const std::size_t LENGTH = 8;
     // bits are stuffed into uints here for compactness
     auto bits_pits_combination = GENERATE(

--- a/tests/scrambling.cpp
+++ b/tests/scrambling.cpp
@@ -22,6 +22,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include <cstddef>
+
 #include "../vendor/catch.hpp"
 
 #include "../dengr/Mode2Sector.hpp"
@@ -65,7 +67,7 @@ SCENARIO("Sectors can be scrambled according to ECMA-130 Annex B") {
     Mode2Sector raw_sector;
     ScrambledSector scrambled_sector;
     // try and read them both into the corresponding data structures
-    for (size_t i = 0; i < 2352; i++) {
+    for (std::size_t i = 0; i < 2352; i++) {
         // because C++ is a strict language, need a temporary to cast bytes
         char input_temp[1], output_temp[1];
         input_file.read(input_temp, 1);


### PR DESCRIPTION
Adds functions for converting sequences of channel bits to and from sequences of pits and lands.

This implements NRZI encoding to achieve this in line with the spec.

Closes #3