### PR TITLE
Improve docs: Document main namespace explicitly, remove EXTRACT_ALL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ before_script:
 script:
   - cmake --build . -j
   - ctest
+  - cd ..
+  - doxygen Doxyfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
         apt:
           packages:
             - doxygen
+            - graphviz
       before_install: skip
       before_script: skip
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
   # install doxygen with "brew install doxygen" on macOS OR "choco install doxygen" on Windows
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install doxygen; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install doxygen.portable; fi
+  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install doxygen.install; fi
 before_script:
   - cd build
   - cmake -G "$CMAKE_GENERATOR" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-10
+            - doxygen
       env:
         - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=g++-10"
     - name: Clang 10 on Linux
@@ -24,19 +25,22 @@ matrix:
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - clang-10
+            - doxygen
       env:
         - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++-10"
     - name: Clang 10 on macOS
       os: osx
       osx_image: xcode10.3 # this image has CLang 10.0.1 (same as Linux) and CMake 3.15
       env:
-        - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++"
+        - MATRIX_EVAL="PACKAGE_MANAGER=brew && CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++"
     - name: MSVC 2017 on Windows
       os: windows
       env:
-        - MATRIX_EVAL="CMAKE_GENERATOR='Visual Studio 15 2017'"
+        - MATRIX_EVAL="PACKAGE_MANAGER=choco && CMAKE_GENERATOR='Visual Studio 15 2017'"
 before_install:
   - eval "${MATRIX_EVAL}"
+  # install doxygen with "brew install doxygen" on macOS OR "choco install doxygen" on Windows
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then $PACKAGE_MANAGER install doxygen; fi
 before_script:
   - cd build
   - cmake -G "$CMAKE_GENERATOR" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
   # install doxygen with "brew install doxygen" on macOS OR "choco install doxygen" on Windows
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install doxygen; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install doxygen.install; fi
+  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install doxygen.portable; fi
 before_script:
   - cd build
   - cmake -G "$CMAKE_GENERATOR" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
   # install doxygen with "brew install doxygen" on macOS OR "choco install doxygen" on Windows
-  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then $PACKAGE_MANAGER install doxygen; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install doxygen; fi
+  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install doxygen.install; fi
 before_script:
   - cd build
   - cmake -G "$CMAKE_GENERATOR" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
       before_script: skip
       script:
         - doxygen Doxyfile
-  include:
     - name: GCC 10 on Linux
       os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ language: cpp
 cache: ccache
 matrix:
   include:
+    - name: Docs only on Linux
+      os: linux
+      addons:
+        apt:
+          packages:
+            - doxygen
+      before_install: skip
+      before_script: skip
+      script:
+        - doxygen Doxyfile
+  include:
     - name: GCC 10 on Linux
       os: linux
       addons:
@@ -11,7 +22,6 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-10
-            - doxygen
       env:
         - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=g++-10"
     - name: Clang 10 on Linux
@@ -25,28 +35,22 @@ matrix:
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - clang-10
-            - doxygen
       env:
         - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++-10"
     - name: Clang 10 on macOS
       os: osx
       osx_image: xcode10.3 # this image has CLang 10.0.1 (same as Linux) and CMake 3.15
       env:
-        - MATRIX_EVAL="PACKAGE_MANAGER=brew && CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++"
+        - MATRIX_EVAL="CMAKE_GENERATOR='Unix Makefiles' && CXX=clang++"
     - name: MSVC 2017 on Windows
       os: windows
       env:
-        - MATRIX_EVAL="PACKAGE_MANAGER=choco && CMAKE_GENERATOR='Visual Studio 15 2017'"
+        - MATRIX_EVAL="CMAKE_GENERATOR='Visual Studio 15 2017'"
 before_install:
   - eval "${MATRIX_EVAL}"
-  # install doxygen with "brew install doxygen" on macOS OR "choco install doxygen" on Windows
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install doxygen; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install doxygen.install; fi
 before_script:
   - cd build
   - cmake -G "$CMAKE_GENERATOR" ..
 script:
   - cmake --build . -j
   - ctest
-  - cd ..
-  - doxygen Doxyfile

--- a/Doxyfile
+++ b/Doxyfile
@@ -416,7 +416,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.

--- a/Doxyfile
+++ b/Doxyfile
@@ -705,7 +705,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/Doxyfile
+++ b/Doxyfile
@@ -743,7 +743,7 @@ WARN_NO_PARAMDOC       = YES
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/Doxyfile
+++ b/Doxyfile
@@ -705,7 +705,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = YES
+QUIET                  = NO
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/Doxyfile
+++ b/Doxyfile
@@ -442,7 +442,7 @@ EXTRACT_STATIC         = NO
 # for Java sources.
 # The default value is: YES.
 
-EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_CLASSES  = NO
 
 # This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are
@@ -827,7 +827,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = *.py
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/dengr/ChannelByte.hpp
+++ b/dengr/ChannelByte.hpp
@@ -42,10 +42,10 @@ namespace com::saxbophone::dengr {
      * standard (ECMA-130) itself, but is used in this library as a term of
      * convenience for the alternative which would be "14-bit byte" (this is
      * incidentally, similar to the phrasing used in ECMA-130).
-     * @warn Don't set the two most significant bits of this type. It's declared
-     * as 16-bit because 14-bit isn't an option, but it should be used as if
-     * it's 14-bit. It might be packed into a 14-bit bitfield in structures that
-     * use it.
+     * @warning Don't set the two most significant bits of this type. It's
+     * declared as 16-bit because 14-bit isn't an option, but it should be used
+     * as if it's 14-bit. It might be packed into a 14-bit bitfield in
+     * structures that use it.
      */
     typedef std::uint16_t ChannelByte;
 }

--- a/dengr/ChannelFrame.hpp
+++ b/dengr/ChannelFrame.hpp
@@ -51,7 +51,7 @@ namespace com::saxbophone::dengr {
          * @note This is always a fixed value.
          * @details As per ECMA-130, sec 19.2, this shall always be following:
          * `100000000001000000000010`
-         * @warn This is a 24-bit value.
+         * @warning This is a 24-bit value.
          */
         static const std::uint32_t SYNC_HEADER;
         /**
@@ -74,8 +74,8 @@ namespace com::saxbophone::dengr {
          * their Merging Bits so they can be used in an array conveniently.
          */
         struct ChannelByteWithMergingBits {
-            ChannelByte byte : 14;
-            MergingBits merging_bits : 3;
+            ChannelByte byte : 14; /**< the ChannelByte to pack */
+            MergingBits merging_bits : 3; /**< the MergingBits to pack */
         };
 
         /**

--- a/dengr/MergingBits.hpp
+++ b/dengr/MergingBits.hpp
@@ -38,10 +38,10 @@ namespace com::saxbophone::dengr {
      * @brief A sequence of 3 Channel bits delimiting each part of a Channel
      * Frame to prevent encoding issues.
      * @details See @e ECMA-130, secs. 19.3 and 19.4 for more information.
-     * @warn Don't set the 5 most significant bits of this type. It's declared
-     * as 8-bit because 3-bit isn't an option, but it should be used as if it's
-     * 3-bit. It might be packed into a 3-bit bitfield in structures that use
-     * it.
+     * @warning Don't set the 5 most significant bits of this type. It's
+     * declared as 8-bit because 3-bit isn't an option, but it should be used
+     * as if it's 3-bit. It might be packed into a 3-bit bitfield in structures
+     * that use it.
      */
     typedef std::uint8_t MergingBits;
 }

--- a/dengr/Mode2Sector.hpp
+++ b/dengr/Mode2Sector.hpp
@@ -52,7 +52,7 @@ namespace com::saxbophone::dengr {
     struct Mode2Sector {
         /**
          * @brief The Bytes that make up the data contained in this Sector
-         * @warn At this point, we are deviating from the ECMA-130 standard as
+         * @warning At this point, we are deviating from the ECMA-130 standard as
          * we are appropriating the first 16 bytes that are supposed to be
          * reserved for Sync pattern and addressing Header, for usage as our own
          * data. User Data isn't actually supposed to take up more than 2336

--- a/dengr/dengr.hpp
+++ b/dengr/dengr.hpp
@@ -1,0 +1,40 @@
+/**
+ * @file
+ *
+ * @remarks This source file forms part of DENGR, a piece of software which
+ * produces disc images which produce visible images on the recording side when
+ * burned to Compact Disc.
+ *
+ * @author Joshua Saxby <joshua.a.saxby@gmail.com>
+ * @date 2020
+ *
+ * @copyright Copyright (C) 2020 Joshua Saxby
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * @copyright
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef COM_SAXBOPHONE_DENGR_DENGR
+#define COM_SAXBOPHONE_DENGR_DENGR
+
+/**
+ * @brief Main top-level namespace for the DENGR's own support library
+ * @details Most of the data types used by DENGR are in this namespace, most
+ * non-member functions are defined in namespaces further nested in this one.
+ */
+namespace com::saxbophone::dengr {
+}
+
+#endif // include guard


### PR DESCRIPTION
This means that now, the `dengr` namespace has a brief and description, and we can now remove the `EXTRACT_ALL` doxygen config setting (this would cause more stuff to get included in the docs than I wish, including python scripts and docs of CPP sources).