### PR TITLE
Put encoder/decoder tables for EFM in private unnamed namespace

### DIFF
--- a/dengr/eight_to_fourteen.cpp
+++ b/dengr/eight_to_fourteen.cpp
@@ -99,11 +99,9 @@ namespace {
          */
         std::array<PresentByte, 0b10010010010010 + 1> lookup_table;
     };
-}
 
-namespace com::saxbophone::dengr::eight_to_fourteen {
     /**
-     * @brief Lookup table used to encode 8-bit bytes into 14-bit EFM codes
+     * Lookup table used to encode 8-bit bytes into 14-bit EFM codes
      */
     static constexpr std::array<ChannelByte, 256> ENCODING_TABLE = {
         0b01001000100000,
@@ -365,10 +363,12 @@ namespace com::saxbophone::dengr::eight_to_fourteen {
     };
 
     /**
-     * @brief Lookup table used to decode 14-bit EFM codes into 8-bit bytes
+     * Lookup table used to decode 14-bit EFM codes into 8-bit bytes
      */
     static constexpr DecoderLookupTable DECODING_TABLE(ENCODING_TABLE);
+}
 
+namespace com::saxbophone::dengr::eight_to_fourteen {
     ChannelByte encode(Byte byte) {
         /*
          * NOTE: no need to use the bounds-checking interface of std::array here


### PR DESCRIPTION
Don't know why this wasn't done in the first place, they are implementation details and should not be exposed publicly (even though they're not in the header, I don't even want the symbols available at least not implicitly).