### PR TITLE
Enable out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ enable_testing()
 include(CTest)
 include(Catch)
 
-catch_discover_tests(unit_tests)
+catch_discover_tests(unit_tests WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
 
 install(
     TARGETS dengr


### PR DESCRIPTION
The only thing preventing this was the tests requiring access to some files to run
The simple fix for now is to have the tests run in that directory.
There might be a better fix option but this will do for now.